### PR TITLE
Fix to allow running on Emacs 29

### DIFF
--- a/init.el
+++ b/init.el
@@ -70,3 +70,16 @@
 
 ;;; init.el ends here
 
+(custom-set-variables
+ ;; custom-set-variables was added by Custom.
+ ;; If you edit it by hand, you could mess it up, so be careful.
+ ;; Your init file should contain only one such instance.
+ ;; If there is more than one, they won't work right.
+ '(package-selected-packages
+   '(anaconda-mode yaml-mode cmake-font-lock flycheck yasnippet company helm base16-theme)))
+(custom-set-faces
+ ;; custom-set-faces was added by Custom.
+ ;; If you edit it by hand, you could mess it up, so be careful.
+ ;; Your init file should contain only one such instance.
+ ;; If there is more than one, they won't work right.
+ )

--- a/init.el
+++ b/init.el
@@ -69,17 +69,3 @@
 		      user-emacs-directory))
 
 ;;; init.el ends here
-
-(custom-set-variables
- ;; custom-set-variables was added by Custom.
- ;; If you edit it by hand, you could mess it up, so be careful.
- ;; Your init file should contain only one such instance.
- ;; If there is more than one, they won't work right.
- '(package-selected-packages
-   '(anaconda-mode yaml-mode cmake-font-lock flycheck yasnippet company helm base16-theme)))
-(custom-set-faces
- ;; custom-set-faces was added by Custom.
- ;; If you edit it by hand, you could mess it up, so be careful.
- ;; Your init file should contain only one such instance.
- ;; If there is more than one, they won't work right.
- )

--- a/modules/aesthetics.org
+++ b/modules/aesthetics.org
@@ -36,7 +36,10 @@ I like =base16-theme='s 3024 because of it's pure black background
 that looks stunning on my OLED screen, and also saves battery.
 
 #+BEGIN_SRC emacs-lisp
-  (load-theme 'base16-3024 t)
+  (use-package base16-theme
+   :ensure t
+   :config
+   (load-theme 'base16-3024 t))
 #+END_SRC
 
 I like to have the fringes of my emacs buffers to be really thin, this
@@ -86,7 +89,7 @@ find it very useful. Until I find a better solution, it stays on
 everywhere:
 
 #+BEGIN_SRC emacs-lisp
-  (global-linum-mode t)
+  (display-line-numbers-mode t)
 #+END_SRC
 
 Line numbering causes the fringe to grow in size as it moves into
@@ -102,7 +105,7 @@ Finally, I set the line numbering background colour to be the same as
 the body's, in this case it's black. 
 
 #+BEGIN_SRC emacs-lisp
-  (set-face-background 'linum "#000")
+  (set-face-background 'line-number "#000")
 #+END_SRC
 
 * Mode line


### PR DESCRIPTION
Upon running simplemacs in emacs 29, a few issues were faced when running for the first time:

**Issues:**
1. `(load-theme 'base16-3024)` is called, but the package containing that theme is never explicitly installed (error: `Unable to find theme file for ‘base16-3024’`).
2.  `global-linum-mode` to be a void variable: (error: `Symbol's function definition is void: global-linum-mode`).
    **Fix: Replace `global-linum-mode` with `display-line-numbers-mode`**
3.  `linum` is not a valid face (error: `error: Invalid face, linum`).

Issues 2 and 3 were caused by the `linum.el` package becoming obsolete in emacs 29 ([source](https://git.savannah.gnu.org/cgit/emacs.git/tree/etc/NEWS?h=emacs-29&id=ef8838c3a5f041769f72758b831eb3fa7a130fb9#n493))

**Fixes:**
1.  Wrapped in a `use-package` function installing the theme package and setting the theme within the :config keyword.
2.  Replaced `global-linum-mode` with `display-line-numbers-mode`
3.  Replaced `linum` with `line-numbers`   
